### PR TITLE
getallheaders patch

### DIFF
--- a/StructuredDynamics/osf/ws/framework/WebService.php
+++ b/StructuredDynamics/osf/ws/framework/WebService.php
@@ -218,7 +218,15 @@ abstract class WebService
   
   function __construct()
   { 
-    $this->headers = array_change_key_case(getallheaders(), CASE_UPPER);
+    // Get headers either via mod_php function or custom implementation
+    if(function_exists('getallheaders'))
+    {
+       $this->headers = array_change_key_case(getallheaders(), CASE_UPPER);
+    }
+    else
+    {
+       $this->headers = array_change_key_case($this->osf_getallheaders(), CASE_UPPER);
+    }
 
     // Load INI settings
     $osf_ini = parse_ini_file(self::$osf_ini . "osf.ini", TRUE);

--- a/StructuredDynamics/osf/ws/framework/WebService.php
+++ b/StructuredDynamics/osf/ws/framework/WebService.php
@@ -773,7 +773,37 @@ abstract class WebService
       @author Frederick Giasson, Structured Dynamics LLC.
   */
   abstract public function ws_serialize();
- 
+
+  /** getallheaders function inspired in mod_php
+   *  See http://www.php.net/manual/en/function.getallheaders.php
+
+      @return returns array of headers.
+    
+      @author Frederick Giasson, Structured Dynamics LLC.
+      @author Luís Algarvio <lp.algarvio@gmail.com>
+  */
+  protected function osf_getallheaders()
+  {
+    if (!is_array($_SERVER))
+    {
+      return array();
+    }
+    $headers = array();
+    foreach ($_SERVER as $name => $value)
+    {
+      
+      if (substr($name, 0, 5) == 'HTTP_')
+      {
+        $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+      }
+      elseif(strtolower($name) == 'authorization')
+      {
+        $headers[$name] = $value;
+      }
+    }
+    return $headers;
+  }
+
   /** Core web service serializations supported by all OSF web service
              endpoints. This function is normally called within each web service
              function: ws_serialize(). Additionally, ws_serialize() can add more


### PR DESCRIPTION
Resolves header problems with non mod_php installations by adding a custom implementation for the getallheaders function. It also retains Authorization header as a copy in the HTTP_ namespace for setups that might filter out one or the other header.
